### PR TITLE
refactor!: rename lsp to copilot_ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ return {
     "copilotlsp-nvim/copilot-lsp",
     init = function()
         vim.g.copilot_nes_debounce = 500
-        vim.lsp.enable("copilot")
+        vim.lsp.enable("copilot_ls")
         vim.keymap.set("n", "<tab>", function()
             -- Try to jump to the start of the suggestion edit.
             -- If already at the start, then apply the pending suggestion and jump to the end of the edit.

--- a/lsp/copilot_ls.lua
+++ b/lsp/copilot_ls.lua
@@ -3,7 +3,7 @@ local version = vim.version()
 ---@type vim.lsp.Config
 return {
     --NOTE: This name means that existing blink completion works
-    name = "copilot",
+    name = "copilot_ls",
     cmd = {
         "copilot-language-server",
         "--stdio",

--- a/lua/copilot-lsp/completion/init.lua
+++ b/lua/copilot-lsp/completion/init.lua
@@ -19,7 +19,7 @@ local function handle_inlineCompletion_response(_results, _ctx, _config)
     -- for _, result in pairs(results1) do
     --     --TODO: Ghost text for completions
     --     -- This is where we show the completion results
-    --     -- However, the LSP being named "copilot" is enough for blink-cmp to show the completion
+    --     -- However, the LSP being named "copilot_ls" is enough for blink-cmp to show the completion
     -- end
 end
 

--- a/tests/nes/test_nes.lua
+++ b/tests/nes/test_nes.lua
@@ -20,14 +20,24 @@ T["nes"] = MiniTest.new_set({
     },
 })
 
+T["nes"]["lsp starts"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    local lsp_count = child.lua_func(function()
+        local count = 0
+        local clients = vim.lsp.get_clients()
+        for _, _ in pairs(clients) do
+            --NOTE: #clients doesn't work, so we count in the loop
+            count = count + 1
+        end
+        return count
+    end)
+    eq(lsp_count, 1)
+end
+
 T["nes"]["same line edit"] = function()
     child.cmd("edit tests/fixtures/sameline_edit.txt")
     ref(child.get_screenshot())
     vim.uv.sleep(500)
-    local lsp_name = child.lua_func(function()
-        return vim.lsp.get_clients()[1].name
-    end)
-    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -44,10 +54,6 @@ T["nes"]["multi line edit"] = function()
     child.cmd("edit tests/fixtures/multiline_edit.txt")
     ref(child.get_screenshot())
     vim.uv.sleep(500)
-    local lsp_name = child.lua_func(function()
-        return vim.lsp.get_clients()[1].name
-    end)
-    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -64,10 +70,6 @@ T["nes"]["removal edit"] = function()
     child.cmd("edit tests/fixtures/removal_edit.txt")
     ref(child.get_screenshot())
     vim.uv.sleep(500)
-    local lsp_name = child.lua_func(function()
-        return vim.lsp.get_clients()[1].name
-    end)
-    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -88,10 +90,6 @@ T["nes"]["add only edit"] = function()
     child.cmd("edit tests/fixtures/addonly_edit.txt")
     ref(child.get_screenshot())
     vim.uv.sleep(500)
-    local lsp_name = child.lua_func(function()
-        return vim.lsp.get_clients()[1].name
-    end)
-    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -119,10 +117,6 @@ T["nes"]["highlights replacement"] = function()
     end)
     ref(child.get_screenshot())
     vim.uv.sleep(500)
-    local lsp_name = child.lua_func(function()
-        return vim.lsp.get_clients()[1].name
-    end)
-    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)

--- a/tests/nes/test_nes.lua
+++ b/tests/nes/test_nes.lua
@@ -10,10 +10,10 @@ T["nes"] = MiniTest.new_set({
             child.restart({ "-u", "scripts/minimal_init.lua" })
             child.lua_func(function()
                 vim.g.copilot_nes_debounce = 450
-                vim.lsp.config("copilot", {
+                vim.lsp.config("copilot_ls", {
                     cmd = require("tests.mock_lsp").server,
                 })
-                vim.lsp.enable("copilot")
+                vim.lsp.enable("copilot_ls")
             end)
         end,
         post_once = child.stop,
@@ -27,7 +27,7 @@ T["nes"]["same line edit"] = function()
     local lsp_name = child.lua_func(function()
         return vim.lsp.get_clients()[1].name
     end)
-    eq(lsp_name, "copilot")
+    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -47,7 +47,7 @@ T["nes"]["multi line edit"] = function()
     local lsp_name = child.lua_func(function()
         return vim.lsp.get_clients()[1].name
     end)
-    eq(lsp_name, "copilot")
+    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -67,7 +67,7 @@ T["nes"]["removal edit"] = function()
     local lsp_name = child.lua_func(function()
         return vim.lsp.get_clients()[1].name
     end)
-    eq(lsp_name, "copilot")
+    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -91,7 +91,7 @@ T["nes"]["add only edit"] = function()
     local lsp_name = child.lua_func(function()
         return vim.lsp.get_clients()[1].name
     end)
-    eq(lsp_name, "copilot")
+    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)
@@ -122,7 +122,7 @@ T["nes"]["highlights replacement"] = function()
     local lsp_name = child.lua_func(function()
         return vim.lsp.get_clients()[1].name
     end)
-    eq(lsp_name, "copilot")
+    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         require("copilot-lsp.nes").request_nes(copilot)

--- a/tests/test_signin.lua
+++ b/tests/test_signin.lua
@@ -1,4 +1,3 @@
-local eq = MiniTest.expect.equality
 local ref = MiniTest.expect.reference_screenshot
 
 local child = MiniTest.new_child_neovim()
@@ -23,10 +22,6 @@ T["signin"]["shows modal"] = function()
     child.cmd("edit tests/fixtures/signin.txt")
     ref(child.get_screenshot())
     vim.uv.sleep(500)
-    local lsp_name = child.lua_func(function()
-        return vim.lsp.get_clients()[1].name
-    end)
-    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         copilot.handlers["signIn"](nil, {

--- a/tests/test_signin.lua
+++ b/tests/test_signin.lua
@@ -9,10 +9,10 @@ T["signin"] = MiniTest.new_set({
         pre_case = function()
             child.restart({ "-u", "scripts/minimal_init.lua" })
             child.lua_func(function()
-                vim.lsp.config("copilot", {
+                vim.lsp.config("copilot_ls", {
                     cmd = require("tests.mock_lsp").server,
                 })
-                vim.lsp.enable("copilot")
+                vim.lsp.enable("copilot_ls")
             end)
         end,
         post_once = child.stop,
@@ -26,7 +26,7 @@ T["signin"]["shows modal"] = function()
     local lsp_name = child.lua_func(function()
         return vim.lsp.get_clients()[1].name
     end)
-    eq(lsp_name, "copilot")
+    eq(lsp_name, "copilot_ls")
     child.lua_func(function()
         local copilot = vim.lsp.get_clients()[1]
         copilot.handlers["signIn"](nil, {


### PR DESCRIPTION
Update the LSP client name from "copilot" to "copilot_ls" across the config, tests, and completion modules. This change ensures consistency with the new naming convention and enables correct integration with blink-cmp.

This also allows the plugin to co-exist with copilot.lua

Users will need to update references in `lsp.config.enable` calls

- Closes #4 
- Closes #13 