### PR TITLE
fix(util): skip captures out of order

### DIFF
--- a/lua/copilot-lsp/util.lua
+++ b/lua/copilot-lsp/util.lua
@@ -142,7 +142,7 @@ function M.hl_text_to_virt_lines(text, lang)
 
     vim.iter(captures):each(function(cap)
         -- skip if the capture is before the current position
-        if cap.end_row < curr_row or (cap.end_row == curr_row and cap.end_col < curr_col) then
+        if cap.end_row < curr_row or (cap.end_row == curr_row and cap.end_col <= curr_col) then
             return
         end
 


### PR DESCRIPTION
Close #24 

Normally captures are in order, but the top-level comment will be captured as `operator` at the end. idk why, seems like it's ok to skip it.

```
hl_text_to_virt_lines([[// anything]], 'go')
```