### PR TITLE
fix(nes): only request if attached and notify on display

### DIFF
--- a/lua/copilot-lsp/nes/ui.lua
+++ b/lua/copilot-lsp/nes/ui.lua
@@ -181,10 +181,11 @@ end
 ---@param bufnr integer
 ---@param ns_id integer
 ---@param edits copilotlsp.InlineEdit[]
+---@return boolean
 function M._display_next_suggestion(bufnr, ns_id, edits)
     M.clear_suggestion(bufnr, ns_id)
     if not edits or #edits == 0 then
-        return
+        return false
     end
 
     local suggestion = edits[1]
@@ -290,6 +291,7 @@ function M._display_next_suggestion(bufnr, ns_id, edits)
             return false -- Keep the autocmd
         end,
     })
+    return true
 end
 
 return M

--- a/lua/copilot-lsp/util.lua
+++ b/lua/copilot-lsp/util.lua
@@ -100,7 +100,6 @@ local function merge_captures(captures)
         then
             local prev_hl = type(prev.hl) == "table" and prev.hl or { prev.hl }
             local curr_hl = type(curr.hl) == "table" and curr.hl or { curr.hl }
-            ---@diagnostic disable-next-line: param-type-mismatch
             vim.list_extend(prev_hl, curr_hl)
             curr.hl = prev_hl
         else


### PR DESCRIPTION
Ensure NES requests are only sent if the client is attached to the current buffer. Notify the LSP client with "textDocument/didShowInlineEdit" only when a suggestion is actually displayed.