### PR TITLE
Add support for restoring the last cleared NES suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,15 @@ return {
                         and require("copilot-lsp.nes").walk_cursor_end_edit()
                     )
                 return nil
-            else
-                -- Resolving the terminal's inability to distinguish between `TAB` and `<C-i>` in normal mode
-                return "<C-i>"
             end
+
+            -- optionally: try to re-show the most recent NES suggestion for this buffer
+            if nes.restore_last_nes(bufnr) then
+                return nil
+            end
+
+            -- Resolving the terminal's inability to distinguish between `TAB` and `<C-i>` in normal mode
+            return "<C-i>"
         end, { desc = "Accept Copilot NES suggestion", expr = true })
     end,
 }
@@ -60,6 +65,14 @@ vim.keymap.set("n", "<esc>", function()
     end
 end, { desc = "Clear Copilot suggestion or fallback" })
 ```
+
+#### Re-showing the last cleared suggestion
+
+`require("copilot-lsp.nes").restore_last_nes(bufnr)` returns `true` when it
+re-shows the most recent cleared NES suggestion for the `bufnr` buffer;
+defaults to current buffer. It returns `false` if there is already an active
+suggestion, if nothing has been cleared yet, or if the saved suggestion is
+stale.
 
 ## Default Configuration
 

--- a/lua/copilot-lsp/nes/init.lua
+++ b/lua/copilot-lsp/nes/init.lua
@@ -4,12 +4,120 @@ local utils = require("copilot-lsp.util")
 
 local M = {}
 
+nes_ui.set_stale_checker(function(bufnr)
+    return M.clear_stale_active_nes(bufnr)
+end)
+
 local nes_ns = vim.api.nvim_create_namespace("copilotlsp.nes")
+
+---@param bufnr integer
+---@return integer
+local function get_nes_ns(bufnr)
+    if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+        return nes_ns
+    end
+
+    return vim.b[bufnr].copilotlsp_nes_namespace_id or nes_ns
+end
+
+---@param state? copilotlsp.InlineEdit
+---@return boolean
+local function is_valid_nes(state)
+    return state ~= nil
+        and state.textDocument ~= nil
+        and state.textDocument.uri ~= nil
+        and state.range ~= nil
+        and state.range.start ~= nil
+        and state.range["end"] ~= nil
+        and state.newText ~= nil
+end
+
+---@param bufnr integer
+---@return integer?
+local function get_buf_version(bufnr)
+    return vim.lsp.util.buf_versions[bufnr]
+end
+
+---@param bufnr integer
+---@return copilotlsp.InlineEdit?
+local function get_last_nes(bufnr)
+    return vim.b[bufnr].copilotlsp_nes_last_state
+end
+
+---@param bufnr integer
+local function clear_last_nes(bufnr)
+    vim.b[bufnr].copilotlsp_nes_last_state = nil
+    vim.b[bufnr].copilotlsp_nes_last_version = nil
+end
+
+---@param bufnr integer
+---@return integer?
+local function get_nes_state_version(bufnr)
+    return vim.b[bufnr].copilotlsp_nes_state_version
+end
+
+---@param bufnr integer
+---@return integer?
+local function get_nes_last_version(bufnr)
+    return vim.b[bufnr].copilotlsp_nes_last_version
+end
+
+---@param bufnr integer
+---@param state copilotlsp.InlineEdit
+---@param request_version integer?
+---@return boolean
+local function is_stale_nes(bufnr, state, request_version)
+    if not is_valid_nes(state) then
+        return true
+    end
+
+    local current_version = get_buf_version(bufnr)
+
+    if request_version == nil or current_version == nil then
+        return true
+    end
+
+    return request_version ~= current_version
+end
+
+---@param bufnr? integer
+---@return boolean --if a stale active NES was cleared
+function M.clear_stale_active_nes(bufnr)
+    bufnr = bufnr and bufnr > 0 and bufnr or vim.api.nvim_get_current_buf()
+
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+        return false
+    end
+
+    local state = vim.b[bufnr].nes_state
+    if not state then
+        return false
+    end
+
+    if not is_stale_nes(bufnr, state, get_nes_state_version(bufnr)) then
+        return false
+    end
+
+    vim.b[bufnr].nes_jump = false
+    nes_ui.clear_suggestion(bufnr, get_nes_ns(bufnr), false)
+    return true
+end
+
+---@param bufnr integer
+local function clear_pending_nes(bufnr)
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+    end
+
+    vim.b[bufnr].nes_jump = false
+    nes_ui.clear_suggestion(bufnr, get_nes_ns(bufnr), false)
+end
 
 ---@param err lsp.ResponseError?
 ---@param result copilotlsp.copilotInlineEditResponse
 ---@param ctx lsp.HandlerContext
-local function handle_nes_response(err, result, ctx)
+---@param request_version integer?
+local function handle_nes_response(request_version, err, result, ctx)
     if err then
         vim.notify("[copilot-lsp] " .. err.message)
         return
@@ -18,11 +126,18 @@ local function handle_nes_response(err, result, ctx)
     if not vim.api.nvim_buf_is_valid(ctx.bufnr) then
         return
     end
+    if request_version ~= get_buf_version(ctx.bufnr) then
+        return
+    end
+    if not result or not result.edits or #result.edits == 0 then
+        return
+    end
     for _, edit in ipairs(result.edits) do
         --- Convert to textEdit fields
         edit.newText = edit.text
     end
-    if nes_ui._display_next_suggestion(ctx.bufnr, nes_ns, result.edits) then
+    if nes_ui._display_next_suggestion(ctx.bufnr, get_nes_ns(ctx.bufnr), result.edits) then
+        vim.b[ctx.bufnr].copilotlsp_nes_state_version = request_version
         local client = vim.lsp.get_client_by_id(ctx.client_id)
         assert(client, errs.ErrNotStarted)
         client:notify("textDocument/didShowInlineEdit", {
@@ -42,11 +157,13 @@ function M.request_nes(copilot_lss)
     end
     assert(copilot_lss, errs.ErrNotStarted)
     if copilot_lss.attached_buffers[bufnr] then
-        local version = vim.lsp.util.buf_versions[bufnr]
+        local version = get_buf_version(bufnr)
         local pos_params = vim.lsp.util.make_position_params(0, "utf-16")
         ---@diagnostic disable-next-line: inject-field
         pos_params.textDocument.version = version
-        copilot_lss:request("textDocument/copilotInlineEdit", pos_params, handle_nes_response)
+        copilot_lss:request("textDocument/copilotInlineEdit", pos_params, function(err, result, ctx)
+            handle_nes_response(version, err, result, ctx)
+        end)
     end
 end
 
@@ -158,18 +275,54 @@ function M.apply_pending_nes(bufnr)
     if not state then
         return false
     end
+    if M.clear_stale_active_nes(bufnr) then
+        return false
+    end
+    local active_version = get_nes_state_version(bufnr)
     vim.schedule(function()
+        if is_stale_nes(bufnr, state, active_version) then
+            clear_pending_nes(bufnr)
+            return
+        end
         utils.apply_inline_edit(state)
         vim.b[bufnr].nes_jump = false
-        nes_ui.clear_suggestion(bufnr, nes_ns)
+        nes_ui.clear_suggestion(bufnr, get_nes_ns(bufnr), false)
     end)
     return true
+end
+
+--- Re-show the last dismissed NES suggestion for the buffer if it is still valid.
+---@param bufnr? integer
+---@return boolean --if the nes was restored
+function M.restore_last_nes(bufnr)
+    bufnr = bufnr and bufnr > 0 and bufnr or vim.api.nvim_get_current_buf()
+
+    if not vim.api.nvim_buf_is_valid(bufnr) or vim.b[bufnr].nes_state then
+        return false
+    end
+
+    local state = get_last_nes(bufnr)
+    if not state then
+        return false
+    end
+
+    local last_version = get_nes_last_version(bufnr)
+    if is_stale_nes(bufnr, state, last_version) then
+        clear_last_nes(bufnr)
+        return false
+    end
+
+    local restored = nes_ui._display_next_suggestion(bufnr, get_nes_ns(bufnr), { vim.deepcopy(state) })
+    if restored then
+        vim.b[bufnr].copilotlsp_nes_state_version = last_version
+    end
+    return restored
 end
 
 ---@param bufnr? integer
 function M.clear_suggestion(bufnr)
     bufnr = bufnr and bufnr > 0 and bufnr or vim.api.nvim_get_current_buf()
-    nes_ui.clear_suggestion(bufnr, nes_ns)
+    nes_ui.clear_suggestion(bufnr, get_nes_ns(bufnr))
 end
 
 --- Clear the current suggestion if it exists
@@ -177,8 +330,7 @@ end
 function M.clear()
     local buf = vim.api.nvim_get_current_buf()
     if vim.b[buf].nes_state then
-        local ns = vim.b[buf].copilotlsp_nes_namespace_id or nes_ns
-        nes_ui.clear_suggestion(buf, ns)
+        nes_ui.clear_suggestion(buf, get_nes_ns(buf))
         return true
     end
     return false

--- a/lua/copilot-lsp/nes/ui.lua
+++ b/lua/copilot-lsp/nes/ui.lua
@@ -1,19 +1,55 @@
 local M = {}
 local config = require("copilot-lsp.config").config
 
+---@type fun(bufnr: integer): boolean|nil
+local stale_checker = nil
+
+---@param cb fun(bufnr: integer): boolean|nil
+function M.set_stale_checker(cb)
+    stale_checker = cb
+end
+
 ---@param bufnr integer
 ---@param ns_id integer
 local function _dismiss_suggestion(bufnr, ns_id)
     pcall(vim.api.nvim_buf_clear_namespace, bufnr, ns_id, 0, -1)
 end
 
+---@param bufnr integer
+local function _ensure_text_change_listener(bufnr)
+    if not vim.api.nvim_buf_is_valid(bufnr) or vim.b[bufnr].copilotlsp_nes_on_lines_attached then
+        return
+    end
+
+    local attached = vim.api.nvim_buf_attach(bufnr, false, {
+        on_lines = function(_, changed_bufnr)
+            if stale_checker then
+                stale_checker(changed_bufnr)
+            end
+        end,
+        on_detach = function(_, detached_bufnr)
+            if vim.api.nvim_buf_is_valid(detached_bufnr) then
+                vim.b[detached_bufnr].copilotlsp_nes_on_lines_attached = nil
+            end
+        end,
+    })
+
+    if attached then
+        vim.b[bufnr].copilotlsp_nes_on_lines_attached = true
+    end
+end
+
 ---@param bufnr? integer
 ---@param ns_id integer
-function M.clear_suggestion(bufnr, ns_id)
+---@param save_last? boolean
+function M.clear_suggestion(bufnr, ns_id, save_last)
     bufnr = bufnr and bufnr > 0 and bufnr or vim.api.nvim_get_current_buf()
     -- Validate buffer exists before accessing buffer-scoped variables
     if not vim.api.nvim_buf_is_valid(bufnr) then
         return
+    end
+    if save_last == nil then
+        save_last = true
     end
     if vim.b[bufnr].nes_jump then
         vim.b[bufnr].nes_jump = false
@@ -26,8 +62,14 @@ function M.clear_suggestion(bufnr, ns_id)
         return
     end
 
+    if save_last then
+        vim.b[bufnr].copilotlsp_nes_last_state = vim.deepcopy(state)
+        vim.b[bufnr].copilotlsp_nes_last_version = vim.b[bufnr].copilotlsp_nes_state_version
+    end
+
     -- Clear buffer variables
     vim.b[bufnr].nes_state = nil
+    vim.b[bufnr].copilotlsp_nes_state_version = nil
     vim.b[bufnr].copilotlsp_nes_cursor_moves = nil
     vim.b[bufnr].copilotlsp_nes_last_line = nil
     vim.b[bufnr].copilotlsp_nes_last_col = nil
@@ -195,6 +237,7 @@ function M._display_next_suggestion(bufnr, ns_id, edits)
     vim.b[bufnr].nes_state = suggestion
     vim.b[bufnr].copilotlsp_nes_namespace_id = ns_id
     vim.b[bufnr].copilotlsp_nes_cursor_moves = 1
+    _ensure_text_change_listener(bufnr)
 
     vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
         buffer = bufnr,
@@ -271,23 +314,6 @@ function M._display_next_suggestion(bufnr, ns_id, edits)
                 return true
             end
 
-            return false -- Keep the autocmd
-        end,
-    })
-    -- Also clear on text changes that affect the suggestion area
-    vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
-        buffer = bufnr,
-        callback = function()
-            if not vim.b[bufnr].nes_state then
-                return true
-            end
-            -- Check if the text at the suggestion position has changed
-            local start_line = suggestion.range.start.line
-            -- If the lines are no longer in the buffer, clear the suggestion
-            if start_line >= vim.api.nvim_buf_line_count(bufnr) then
-                M.clear_suggestion(bufnr, ns_id)
-                return true
-            end
             return false -- Keep the autocmd
         end,
     })

--- a/tests/nes/test_nes.lua
+++ b/tests/nes/test_nes.lua
@@ -23,6 +23,47 @@ T["nes"] = MiniTest.new_set({
     },
 })
 
+local function request_nes()
+    child.lua_func(function()
+        local copilot = vim.lsp.get_clients()[1]
+        require("copilot-lsp.nes").request_nes(copilot)
+    end)
+    vim.uv.sleep(500)
+end
+
+local function get_content()
+    return table.concat(child.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+end
+
+local function clear_nes()
+    return child.lua_func(function()
+        return require("copilot-lsp.nes").clear()
+    end)
+end
+
+local function restore_last_nes()
+    return child.lua_func(function()
+        return require("copilot-lsp.nes").restore_last_nes()
+    end)
+end
+
+local function change_current_buffer_line(new_line)
+    child.lua_func(function(line)
+        vim.api.nvim_buf_set_lines(0, 0, 1, false, { line })
+    end, new_line)
+end
+
+local function wait_for_active_nes(bufnr, should_exist)
+    return child.lua_func(function(target_bufnr, expected)
+        vim.wait(1000, function()
+            local has_state = vim.b[target_bufnr].nes_state ~= nil
+            return has_state == expected
+        end)
+
+        return vim.b[target_bufnr].nes_state ~= nil
+    end, bufnr or child.api.nvim_get_current_buf(), should_exist)
+end
+
 T["nes"]["lsp starts"] = function()
     child.cmd("edit tests/fixtures/sameline_edit.txt")
     local lsp_count = child.lua_func(function()
@@ -35,6 +76,225 @@ T["nes"]["lsp starts"] = function()
         return count
     end)
     eq(lsp_count, 1)
+end
+
+T["nes"]["restore_last_nes returns false without saved suggestion"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+
+    local result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        return {
+            restored = require("copilot-lsp.nes").restore_last_nes(),
+            active = vim.b[bufnr].nes_state ~= nil,
+            saved = vim.b[bufnr].copilotlsp_nes_last_state ~= nil,
+        }
+    end)
+    eq(result.restored, false)
+    eq(result.active, false)
+    eq(result.saved, false)
+end
+
+T["nes"]["clear saves last dismissed suggestion"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+
+    local result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        local state = vim.deepcopy(vim.b[bufnr].nes_state)
+        return {
+            cleared = require("copilot-lsp.nes").clear(),
+            active = vim.b[bufnr].nes_state ~= nil,
+            saved = vim.b[bufnr].copilotlsp_nes_last_state ~= nil,
+            matches = vim.deep_equal(vim.b[bufnr].copilotlsp_nes_last_state, state),
+        }
+    end)
+    eq(result.cleared, true)
+    eq(result.active, false)
+    eq(result.saved, true)
+    eq(result.matches, true)
+end
+
+T["nes"]["restore_last_nes restores dismissed suggestion"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+    clear_nes()
+
+    local result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        local saved = vim.deepcopy(vim.b[bufnr].copilotlsp_nes_last_state)
+        return {
+            restored = require("copilot-lsp.nes").restore_last_nes(),
+            active = vim.b[bufnr].nes_state ~= nil,
+            matches = vim.deep_equal(vim.b[bufnr].nes_state, saved),
+            second = require("copilot-lsp.nes").restore_last_nes(),
+        }
+    end)
+    eq(result.restored, true)
+    eq(result.active, true)
+    eq(result.matches, true)
+    eq(result.second, false)
+end
+
+T["nes"]["apply_pending_nes applies matching version"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+
+    local versions = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        return {
+            current = vim.lsp.util.buf_versions[bufnr],
+            request = vim.b[bufnr].copilotlsp_nes_state_version,
+        }
+    end)
+    eq(versions.request, versions.current)
+
+    local applied = child.lua_func(function()
+        return require("copilot-lsp.nes").apply_pending_nes()
+    end)
+    eq(applied, true)
+
+    vim.uv.sleep(100)
+
+    eq(get_content(), "xyz\nbbb\nccc")
+end
+
+T["nes"]["active NES clears on text change"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+
+    local bufnr = child.api.nvim_get_current_buf()
+    change_current_buffer_line("Line one")
+    eq(wait_for_active_nes(bufnr, false), false)
+
+    local result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        return {
+            active = vim.b[bufnr].nes_state ~= nil,
+            saved = vim.b[bufnr].copilotlsp_nes_last_state ~= nil,
+            version = vim.b[bufnr].copilotlsp_nes_state_version,
+        }
+    end)
+    eq(result.active, false)
+    eq(result.saved, false)
+    eq(result.version, nil)
+    eq(get_content(), "Line one\nbbb\nccc")
+end
+
+T["nes"]["stale-cleared NES is not restorable"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+
+    local bufnr = child.api.nvim_get_current_buf()
+    change_current_buffer_line("Line one")
+    eq(wait_for_active_nes(bufnr, false), false)
+
+    local result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        return {
+            restored = require("copilot-lsp.nes").restore_last_nes(),
+            active = vim.b[bufnr].nes_state ~= nil,
+            saved = vim.b[bufnr].copilotlsp_nes_last_state ~= nil,
+        }
+    end)
+    eq(result.restored, false)
+    eq(result.active, false)
+    eq(result.saved, false)
+    eq(get_content(), "Line one\nbbb\nccc")
+end
+
+T["nes"]["restore_last_nes restored suggestion applies"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+    clear_nes()
+
+    local restored = restore_last_nes()
+    eq(restored, true)
+
+    local applied = child.lua_func(function()
+        return require("copilot-lsp.nes").apply_pending_nes()
+    end)
+    eq(applied, true)
+
+    vim.uv.sleep(100)
+
+    eq(get_content(), "xyz\nbbb\nccc")
+end
+
+T["nes"]["restore_last_nes rejects stale saved suggestion"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+    clear_nes()
+
+    child.lua_func(function()
+        vim.api.nvim_buf_set_lines(0, 0, 1, false, { "Line one" })
+    end)
+
+    local result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        return {
+            restored = require("copilot-lsp.nes").restore_last_nes(),
+            applied = require("copilot-lsp.nes").apply_pending_nes(),
+            active = vim.b[bufnr].nes_state ~= nil,
+            saved = vim.b[bufnr].copilotlsp_nes_last_state ~= nil,
+        }
+    end)
+    eq(result.restored, false)
+    eq(result.applied, false)
+    eq(result.active, false)
+    eq(result.saved, false)
+    eq(get_content(), "Line one\nbbb\nccc")
+end
+
+T["nes"]["text-change stale clear is scoped per buffer"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+    child.lua_func(function()
+        vim.g.copilotlsp_first_nes_bufnr = vim.api.nvim_get_current_buf()
+    end)
+
+    child.cmd("edit tests/fixtures/multiline_edit.txt")
+    request_nes()
+
+    local result = child.lua_func(function()
+        local first_bufnr = vim.g.copilotlsp_first_nes_bufnr
+        local second_bufnr = vim.api.nvim_get_current_buf()
+
+        vim.api.nvim_buf_set_lines(second_bufnr, 0, 1, false, { "changed line" })
+        vim.wait(1000, function()
+            return vim.b[second_bufnr].nes_state == nil
+        end)
+
+        return {
+            first_active = vim.b[first_bufnr].nes_state ~= nil,
+            second_active = vim.b[second_bufnr].nes_state ~= nil,
+        }
+    end)
+
+    eq(result.first_active, true)
+    eq(result.second_active, false)
+end
+
+T["nes"]["restore_last_nes is scoped per buffer"] = function()
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+    request_nes()
+    clear_nes()
+
+    child.cmd("edit tests/fixtures/multiline_edit.txt")
+
+    local other_result = child.lua_func(function()
+        local bufnr = vim.api.nvim_get_current_buf()
+        return {
+            restored = require("copilot-lsp.nes").restore_last_nes(),
+            saved = vim.b[bufnr].copilotlsp_nes_last_state ~= nil,
+        }
+    end)
+    eq(other_result.restored, false)
+    eq(other_result.saved, false)
+
+    child.cmd("edit tests/fixtures/sameline_edit.txt")
+
+    local restored = restore_last_nes()
+    eq(restored, true)
 end
 
 T["nes"]["same line edit"] = function()


### PR DESCRIPTION
This is basically the refined version of my config "hack"[1]. This should close #36.

Here is what I've done:

- Implement `require("copilot-lsp.nes").restore_last_nes()` to re-show the most recently cleared suggestion
- Add version tracking to NES suggestions to prevent applying stale edits after buffer changes
- Ensure cleared suggestions are saved per-buffer for later restoration
- Update documentation and add tests for restoration and stale-edit prevention

I'm not sure if the whole version tracking went too far? Before some(?) edits were allowed before NES suggestion became stale. With this change, any edit to the buffer invalidates the NES suggestion and clear it immediately. In the beginning I only had version tracking for the re-show of NES suggestions, but it felt strange, that this behaved differently than the original NES suggestion. In the long run we could try to make NES suggestions stay alive as long as possible (track location via ext marks or so), but I'm not sure if the complexity is worth it.

I also tried to respect the "copilotlsp_nes_namespace_id" stuff everywhere. It felt inconsistent before, so I hope this is an improvement. 

Please let me know what you think.

[1] https://github.com/copilotlsp-nvim/copilot-lsp/issues/36#issuecomment-4062559192