### PR TITLE
feat(nes): add restore_last_nes and improve state handling

### DIFF
--- a/lua/copilot-lsp/nes/init.lua
+++ b/lua/copilot-lsp/nes/init.lua
@@ -166,6 +166,19 @@ function M.apply_pending_nes(bufnr)
     return true
 end
 
+function M.restore_last_nes(bufnr)
+    bufnr = bufnr and bufnr > 0 and bufnr or vim.api.nvim_get_current_buf()
+    ---@type copilotlsp.InlineEdit
+    local state = vim.b[bufnr].nes_state or vim.b[bufnr].last_nes_state
+    if
+        state
+        and state.textDocument.uri == vim.uri_from_bufnr(bufnr)
+        and state.textDocument.version == vim.lsp.util.buf_versions[bufnr]
+    then
+        nes_ui._display_next_suggestion(bufnr, nes_ns, { state })
+    end
+end
+
 ---@param bufnr? integer
 function M.clear_suggestion(bufnr)
     bufnr = bufnr and bufnr > 0 and bufnr or vim.api.nvim_get_current_buf()
@@ -177,8 +190,7 @@ end
 function M.clear()
     local buf = vim.api.nvim_get_current_buf()
     if vim.b[buf].nes_state then
-        local ns = vim.b[buf].copilotlsp_nes_namespace_id or nes_ns
-        nes_ui.clear_suggestion(buf, ns)
+        nes_ui.clear_suggestion(buf, nes_ns)
         return true
     end
     return false

--- a/lua/copilot-lsp/nes/ui.lua
+++ b/lua/copilot-lsp/nes/ui.lua
@@ -27,6 +27,7 @@ function M.clear_suggestion(bufnr, ns_id)
     end
 
     -- Clear buffer variables
+    vim.b[bufnr].last_nes_state = vim.b[bufnr].nes_state
     vim.b[bufnr].nes_state = nil
     vim.b[bufnr].copilotlsp_nes_cursor_moves = nil
     vim.b[bufnr].copilotlsp_nes_last_line = nil
@@ -193,7 +194,6 @@ function M._display_next_suggestion(bufnr, ns_id, edits)
     M._display_preview(bufnr, ns_id, preview)
 
     vim.b[bufnr].nes_state = suggestion
-    vim.b[bufnr].copilotlsp_nes_namespace_id = ns_id
     vim.b[bufnr].copilotlsp_nes_cursor_moves = 1
 
     vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {


### PR DESCRIPTION
Introduce `restore_last_nes` to allow restoring the last NES suggestion for a buffer. Update `clear_suggestion` to save the previous NES state in `last_nes_state` before clearing, enabling restoration. Also, remove unused namespace variable assignment for clarity.

Closes #64 
Closes #40 
Fixes #36 